### PR TITLE
Add some guards against players leaving before the report can be comp…

### DIFF
--- a/lua/autorun/server/sv_cfc_contact_forms.lua
+++ b/lua/autorun/server/sv_cfc_contact_forms.lua
@@ -199,12 +199,13 @@ local function submitPlayerReport( len, ply )
     local reportedSteamID = net.ReadString()
     local urgency = net.ReadString()
     local message = net.ReadString()
+    local reportedPly = player.GetBySteamID( reportedSteamID )
 
     local data = {}
     data["steam_id"] = ply:SteamID()
     data["steam_name"] = ply:GetName()
     data["reported_steam_id"] = reportedSteamID
-    data["reported_steam_name"] = player.GetBySteamID( reportedSteamID ):GetName()
+    data["reported_steam_name"] = reportedPly and reportedPly:GetName() or "<Unknown Name>"
     data["urgency"] = urgency
     data["message"] = message
 
@@ -215,10 +216,11 @@ local function submitStaffReport( len, ply )
     local reportedSteamID = net.ReadString()
     local urgency = net.ReadString()
     local message = net.ReadString()
+    local reportedPly = player.GetBySteamID( reportedSteamID )
 
     local data = {}
     data["reported_steam_id"] = reportedSteamID
-    data["reported_steam_name"] = player.GetBySteamID( reportedSteamID ):GetName()
+    data["reported_steam_name"] = reportedPly and reportedPly:GetName() or "<Unknown Name>"
     data["urgency"] = urgency
     data["message"] = message
 


### PR DESCRIPTION
…leted

The `player.GetBySteamID` returns `false` if it can't find a player. This is a quick guard to prevent that from happening.