### PR TITLE
add in-game alert for admins

### DIFF
--- a/lua/autorun/client/cl_contact_forms.lua
+++ b/lua/autorun/client/cl_contact_forms.lua
@@ -811,7 +811,6 @@ net.Receive( "CFC_ContactForms_FailureAlert", function()
 end )
 
 net.Receive("cfc_contact_forms_alert", function()
-    --local ply = net.ReadEntity() -- reads the reporter's player entity
     local data = net.ReadTable()
     local reporter = player.GetBySteamID(data["steam_id"])
     local reported = player.GetBySteamID(data["reported_steam_id"])
@@ -824,17 +823,19 @@ net.Receive("cfc_contact_forms_alert", function()
 
     chat.AddText(
         reporterRankColor, reporterName,
-        YELLOW, " has submitted a report against ",
+        YELLOW, " has submitted a forms report on ",
         reportedRankColor, reportedName
     ) -- message via chat
-    LocalPlayer():PrintMessage( 4, reporterName .. " made a report!" ) -- message via HUD
+    LocalPlayer():PrintMessage( 4, reporterName .. " has submitted a forms report on " .. reportedName ) -- message via HUD
     local outerColor = Color(41, 41, 41)
     local innerColor = Color(150, 150, 150)
     chat.AddText(
-        darkGrey, "[", innerColor, "CFC Forms", darkGrey, "] ",
-        Color(206,206,206), string.Left( data["message"], 100 )
+        outerColor, "[", innerColor, "CFC Forms", outerColor, "] ",
+        Color(206,206,206), string.Left( data["message"], 99 ),
+        innerColor, "...\nFull message in console."
     ) -- prints reporter's message
-    PrintTable( data ) -- prints the report data in admin's console
+    --PrintTable( data ) -- prints the report data in admin's console
+    print("| Reporter\t: " .. reporterName .. " (" .. data["steam_id"] .. ")\n| Reported\t: " .. reportedName .. " (" .. data["reported_steam_id"] .. ")\n| Full message\t: " .. data["message"])
 end)
 
 concommand.Add( "cfc_forms", CFCContactForms.openForms )

--- a/lua/autorun/client/cl_contact_forms.lua
+++ b/lua/autorun/client/cl_contact_forms.lua
@@ -810,4 +810,11 @@ net.Receive( "CFC_ContactForms_FailureAlert", function()
     )
 end )
 
+net.Receive("Admin_alert", function()
+    local ply = net.ReadString() -- Reads the reporter's name
+    local plyRankColor = net.ReadColor() -- Reads the color of reporter's rank
+    chat.AddText( plyRankColor, ply, YELLOW, " has submitted a report." ) -- messgae via chat
+    LocalPlayer():PrintMessage( 4, ply .. " made a report!" ) -- message via HUD
+end)
+
 concommand.Add( "cfc_forms", CFCContactForms.openForms )

--- a/lua/autorun/client/cl_contact_forms.lua
+++ b/lua/autorun/client/cl_contact_forms.lua
@@ -810,11 +810,31 @@ net.Receive( "CFC_ContactForms_FailureAlert", function()
     )
 end )
 
-net.Receive("Admin_alert", function()
-    local ply = net.ReadString() -- Reads the reporter's name
-    local plyRankColor = net.ReadColor() -- Reads the color of reporter's rank
-    chat.AddText( plyRankColor, ply, YELLOW, " has submitted a report." ) -- messgae via chat
-    LocalPlayer():PrintMessage( 4, ply .. " made a report!" ) -- message via HUD
+net.Receive("cfc_contact_forms_alert", function()
+    --local ply = net.ReadEntity() -- reads the reporter's player entity
+    local data = net.ReadTable()
+    local reporter = player.GetBySteamID(data["steam_id"])
+    local reported = player.GetBySteamID(data["reported_steam_id"])
+
+    local reporterName = reporter:GetName() -- reporter's name
+    local reporterRankColor = team.GetColor(reporter:Team()) -- color of reporter's rank
+
+    local reportedName = reported:GetName() -- reported player name
+    local reportedRankColor = team.GetColor(reported:Team()) -- color of reported player rank
+
+    chat.AddText(
+        reporterRankColor, reporterName,
+        YELLOW, " has submitted a report against ",
+        reportedRankColor, reportedName
+    ) -- message via chat
+    LocalPlayer():PrintMessage( 4, reporterName .. " made a report!" ) -- message via HUD
+    local outerColor = Color(41, 41, 41)
+    local innerColor = Color(150, 150, 150)
+    chat.AddText(
+        darkGrey, "[", innerColor, "CFC Forms", darkGrey, "] ",
+        Color(206,206,206), string.Left( data["message"], 100 )
+    ) -- prints reporter's message
+    PrintTable( data ) -- prints the report data in admin's console
 end)
 
 concommand.Add( "cfc_forms", CFCContactForms.openForms )

--- a/lua/autorun/client/cl_contact_forms.lua
+++ b/lua/autorun/client/cl_contact_forms.lua
@@ -795,6 +795,8 @@ local GREEN = Color( 87, 242, 135 )
 local RED = Color( 237, 66, 69 )
 local YELLOW = Color( 254, 231, 92)
 local BLURPLE = Color( 88, 101, 242 )
+local DARK_GRAY = Color( 41, 41, 41 )
+local LIGHT_GRAY = Color( 150, 150, 150 )
 
 net.Receive( "CFC_ContactForms_SuccessAlert", function()
     surface.PlaySound( "buttons/button5.wav" )
@@ -810,42 +812,47 @@ net.Receive( "CFC_ContactForms_FailureAlert", function()
     )
 end )
 
-net.Receive("CFC_ContactForms_Alert", function()
+net.Receive( "CFC_ContactForms_Alert", function()
     local data = net.ReadTable()
-    local reporter = player.GetBySteamID(data["steam_id"])
-    local reported = player.GetBySteamID(data["reported_steam_id"])
+    local reporter = player.GetBySteamID( data.steam_id )
+    local reported = player.GetBySteamID( data.reported_steam_id )
+
+    if not IsValid( reporter ) or not IsValid( reported ) then return end
 
     local reporterName = reporter:GetName()
-    local reporterRankColor = team.GetColor(reporter:Team())
+    local reporterRankColor = team.GetColor( reporter:Team() )
 
     local reportedName = reported:GetName()
-    local reportedRankColor = team.GetColor(reported:Team())
+    local reportedRankColor = team.GetColor( reported:Team() )
 
     chat.AddText(
         reporterRankColor, reporterName,
         YELLOW, " has submitted a forms report on ",
         reportedRankColor, reportedName
     ) -- message via chat
+
     LocalPlayer():PrintMessage( 4, reporterName .. " has submitted a forms report on " .. reportedName ) -- message via HUD
-    local outerColor = Color(41, 41, 41)
-    local innerColor = Color(150, 150, 150)
+
     chat.AddText(
-        outerColor, "[", innerColor, "CFC Forms", outerColor, "] ",
-        Color(206,206,206), string.Left( data["message"], 99 ),
-        innerColor, "...\nFull message in console."
+        DARK_GRAY, "[", LIGHT_GRAY, "CFC Forms", DARK_GRAY, "] ",
+        Color( 206,206,206 ), string.Left( data.message, 99 ),
+        LIGHT_GRAY, "...\nFull message in console."
     ) -- prints reporter's message
     
-    local reportDataFields = {
-        Reporter = reporterName .. " (" .. data.steam_id .. ")",
-        Reported = reportedName .. " (" .. data.reported_steam_id .. ")",
-        Message = data["message"]
+    local decor = "+" .. string.rep( "-", 80 )
+    local reportDataFields = { -- Each field is a two-index table since string keys have an unpredictable order
+        { "Reporter", reporterName .. " (" .. data.steam_id .. ")" },
+        { "Reported", reportedName .. " (" .. data.reported_steam_id .. ")" },
+        { "Message", data.message }
     }
-    local decor = "+" .. string.rep("-", 80)
-    print(decor)
-    for fieldName, fieldValue in pairs( reportDataFields ) do
-        print( "| " .. fieldName .. "\t: " .. fieldValue )
+
+    MsgN( decor )
+
+    for _, field in ipairs( reportDataFields ) do
+        MsgN( "| " .. field[1] .. "\t: " .. field[2] )
     end
-    print(decor)
+
+    MsgN( decor )
 end)
 
 concommand.Add( "cfc_forms", CFCContactForms.openForms )

--- a/lua/autorun/client/cl_contact_forms.lua
+++ b/lua/autorun/client/cl_contact_forms.lua
@@ -831,7 +831,7 @@ net.Receive( "CFC_ContactForms_Alert", function()
         reportedRankColor, reportedName
     ) -- message via chat
 
-    LocalPlayer():PrintMessage( 4, reporterName .. " has submitted a forms report on " .. reportedName ) -- message via HUD
+    LocalPlayer():PrintMessage( HUD_PRINTCENTER, reporterName .. " has submitted a forms report on " .. reportedName )
 
     chat.AddText(
         DARK_GRAY, "[", LIGHT_GRAY, "CFC Forms", DARK_GRAY, "] ",

--- a/lua/autorun/client/cl_contact_forms.lua
+++ b/lua/autorun/client/cl_contact_forms.lua
@@ -815,11 +815,11 @@ net.Receive("cfc_contact_forms_alert", function()
     local reporter = player.GetBySteamID(data["steam_id"])
     local reported = player.GetBySteamID(data["reported_steam_id"])
 
-    local reporterName = reporter:GetName() -- reporter's name
-    local reporterRankColor = team.GetColor(reporter:Team()) -- color of reporter's rank
+    local reporterName = reporter:GetName()
+    local reporterRankColor = team.GetColor(reporter:Team())
 
-    local reportedName = reported:GetName() -- reported player name
-    local reportedRankColor = team.GetColor(reported:Team()) -- color of reported player rank
+    local reportedName = reported:GetName()
+    local reportedRankColor = team.GetColor(reported:Team())
 
     chat.AddText(
         reporterRankColor, reporterName,
@@ -834,8 +834,18 @@ net.Receive("cfc_contact_forms_alert", function()
         Color(206,206,206), string.Left( data["message"], 99 ),
         innerColor, "...\nFull message in console."
     ) -- prints reporter's message
-    --PrintTable( data ) -- prints the report data in admin's console
-    print("| Reporter\t: " .. reporterName .. " (" .. data["steam_id"] .. ")\n| Reported\t: " .. reportedName .. " (" .. data["reported_steam_id"] .. ")\n| Full message\t: " .. data["message"])
+    
+    local reportDataFields = {
+        Reporter = reporterName .. " (" .. data.steam_id .. ")",
+        Reported = reportedName .. " (" .. data.reported_steam_id .. ")",
+        Message = data["message"]
+    }
+    local decor = "+" .. string.rep("-", 80)
+    print(decor)
+    for fieldName, fieldValue in pairs( reportDataFields ) do
+        print( "| " .. fieldName .. "\t: " .. fieldValue )
+    end
+    print(decor)
 end)
 
 concommand.Add( "cfc_forms", CFCContactForms.openForms )

--- a/lua/autorun/client/cl_contact_forms.lua
+++ b/lua/autorun/client/cl_contact_forms.lua
@@ -810,7 +810,7 @@ net.Receive( "CFC_ContactForms_FailureAlert", function()
     )
 end )
 
-net.Receive("cfc_contact_forms_alert", function()
+net.Receive("CFC_ContactForms_Alert", function()
     local data = net.ReadTable()
     local reporter = player.GetBySteamID(data["steam_id"])
     local reported = player.GetBySteamID(data["reported_steam_id"])

--- a/lua/autorun/server/sv_cfc_contact_forms.lua
+++ b/lua/autorun/server/sv_cfc_contact_forms.lua
@@ -147,38 +147,38 @@ end
 
 util.AddNetworkString( "cfc_contact_forms_alert" )
 
-local function submitFormForPlayer( data, endpoint, ply )
-    local plyName = ply and ply:GetName() or "Unknown Player"
+local function submitFormForPlayer( data, endpoint, formSubmitter )
+    local submitterName = formSubmitter and formSubmitter:GetName() or "Unknown Player"
 
     data["realm"] = REALM
 
-    serverLog( "Sending request for <" .. plyName .. "> with form data: " )
+    serverLog( "Sending request for <" .. submitterName .. "> with form data: " )
     PrintTable( data )
 
-    if not playerCanSubmit( ply ) then return alertPlayer( ply, "You're doing that too much! Please wait or reach out on our discord" ) end
+    if not playerCanSubmit( formSubmitter ) then return alertPlayer( formSubmitter, "You're doing that too much! Please wait or reach out on our discord" ) end
 
     local url = FORM_PROCESSOR_URL ..  endpoint
     http.Post( url, data,
         function( success )
             print( success )
-            sendSuccessAlert( ply )
+            sendSuccessAlert( formSubmitter )
         end,
         function( failure )
-            sendFailureAlert( ply )
+            sendFailureAlert( formSubmitter )
             serverLog( "Request failed with data:" )
             PrintTable( data )
             serverLog( failure )
         end
     )
 
-    recordPlayerSubmission( ply )
+    recordPlayerSubmission( formSubmitter )
 
     local staffRanks = { moderator = true }
-    for _,p in ipairs( player.GetHumans() ) do
-        if p:IsAdmin() or staffRanks[p:GetUserGroup()] then
+    for _, ply in ipairs( player.GetHumans() ) do
+        if ply:IsAdmin() or staffRanks[ply:GetUserGroup()] then
             net.Start( "cfc_contact_forms_alert" )
             net.WriteTable( data ) -- writes the report data
-            net.Send( p )
+            net.Send( ply )
         end
     end
 end

--- a/lua/autorun/server/sv_cfc_contact_forms.lua
+++ b/lua/autorun/server/sv_cfc_contact_forms.lua
@@ -176,7 +176,7 @@ local function submitFormForPlayer( data, endpoint, formSubmitter )
     local staffRanks = { moderator = true }
     for _, ply in ipairs( player.GetHumans() ) do
         if ply:IsAdmin() or staffRanks[ply:GetUserGroup()] then
-            net.Start( "cfc_contact_forms_alert" )
+            net.Start( "CFC_ContactForms_Alert" )
             net.WriteTable( data ) -- writes the report data
             net.Send( ply )
         end

--- a/lua/autorun/server/sv_cfc_contact_forms.lua
+++ b/lua/autorun/server/sv_cfc_contact_forms.lua
@@ -145,6 +145,8 @@ local function sendFailureAlert( ply )
     net.Send( ply )
 end
 
+util.AddNetworkString( "Admin_alert" )
+
 local function submitFormForPlayer( data, endpoint, ply )
     local plyName = ply and ply:GetName() or "Unknown Player"
 
@@ -170,6 +172,15 @@ local function submitFormForPlayer( data, endpoint, ply )
     )
 
     recordPlayerSubmission( ply )
+
+    for _,p in ipairs( player.GetHumans() ) do
+        if p:IsAdmin() then
+            net.Start( "Admin_alert" )
+            net.WriteString( plyName ) -- Writes the reporter's name
+            net.WriteColor( team.GetColor( ply:Team() ) ) -- Writes the reporter's rank color
+            net.Send( p )
+        end
+    end
 end
 
 local function submitContactForm( len, ply )

--- a/lua/autorun/server/sv_cfc_contact_forms.lua
+++ b/lua/autorun/server/sv_cfc_contact_forms.lua
@@ -173,7 +173,7 @@ local function submitFormForPlayer( data, endpoint, ply )
 
     recordPlayerSubmission( ply )
 
-    local staffRanks = { ["Moderator"] = true }
+    local staffRanks = { moderator = true }
     for _,p in ipairs( player.GetHumans() ) do
         if p:IsAdmin() or staffRanks[p:GetUserGroup()] then
             net.Start( "cfc_contact_forms_alert" )

--- a/lua/autorun/server/sv_cfc_contact_forms.lua
+++ b/lua/autorun/server/sv_cfc_contact_forms.lua
@@ -145,7 +145,7 @@ local function sendFailureAlert( ply )
     net.Send( ply )
 end
 
-util.AddNetworkString( "Admin_alert" )
+util.AddNetworkString( "cfc_contact_forms_alert" )
 
 local function submitFormForPlayer( data, endpoint, ply )
     local plyName = ply and ply:GetName() or "Unknown Player"
@@ -173,11 +173,11 @@ local function submitFormForPlayer( data, endpoint, ply )
 
     recordPlayerSubmission( ply )
 
+    local staffRanks = { ["Moderator"] = true }
     for _,p in ipairs( player.GetHumans() ) do
-        if p:IsAdmin() then
-            net.Start( "Admin_alert" )
-            net.WriteString( plyName ) -- Writes the reporter's name
-            net.WriteColor( team.GetColor( ply:Team() ) ) -- Writes the reporter's rank color
+        if p:IsAdmin() or staffRanks[p:GetUserGroup()] then
+            net.Start( "cfc_contact_forms_alert" )
+            net.WriteTable( data ) -- writes the report data
             net.Send( p )
         end
     end

--- a/lua/autorun/server/sv_cfc_contact_forms.lua
+++ b/lua/autorun/server/sv_cfc_contact_forms.lua
@@ -145,7 +145,7 @@ local function sendFailureAlert( ply )
     net.Send( ply )
 end
 
-util.AddNetworkString( "cfc_contact_forms_alert" )
+util.AddNetworkString( "CFC_ContactForms_Alert" )
 
 local function submitFormForPlayer( data, endpoint, formSubmitter )
     local submitterName = formSubmitter and formSubmitter:GetName() or "Unknown Player"


### PR DESCRIPTION
add in-game alert to admins for a player report. After making a report all admins in-game will get a colored chat message with the reporter's name as well as a HUD message on their screen.