### PR TITLE
Fixed client error & players are anonymous when making staff reports

### DIFF
--- a/lua/autorun/server/sv_cfc_contact_forms.lua
+++ b/lua/autorun/server/sv_cfc_contact_forms.lua
@@ -172,6 +172,7 @@ local function submitFormForPlayer( data, endpoint, formSubmitter )
     )
 
     recordPlayerSubmission( formSubmitter )
+    if endpoint == "staff-report" then return end
 
     local staffRanks = { moderator = true }
     for _, ply in ipairs( player.GetHumans() ) do


### PR DESCRIPTION
This will make players who are making staff reports against admins be completely anonymous and wont network the information to the admin clients which also fixes the client side error.